### PR TITLE
Underscore templates are quite speedy as of 1.3.3.

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
 				<h2>Plates.js</h2>
 				<a href="https://github.com/flatiron/plates">github</a>
 			</div>
-			<div class="add client-side server-side logicful compile string format">
+			<div class="add client-side server-side logicful compile string format speedy">
 				<h2>Underscore templates</h2>
 				<a href="http://documentcloud.github.com/underscore/#template">project</a>
 			</div>


### PR DESCRIPTION
`with` blocks are optional in underscore 1.3.3, yielding large [performance improvements](http://jsperf.com/dom-vs-innerhtml-based-templating/390).
