### PR TITLE
Add "no longer maintained" message to the page, with a link to the README

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 	<body>
 		<a href="https://github.com/garann/template-chooser" class="forkme"><img src="http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>
 		<h1>Template-Engine-Chooser!</h1>
+		<h2 style="text-align:center"><span style="; color: yellow">This project is no longer maintained</span> &mdash; <a href="https://github.com/garann/template-chooser/blob/gh-pages/README.md" style="color:#55F">more info</a></h2>
 		<div class="criteria">
 			<fieldset>
 				<legend>Is this for use on the client or the server?</legend>


### PR DESCRIPTION
Since you're no longer maintaining this site, it's likely to go into a gradual state of linkrot, and become increasingly out of date. It's currently the top result in Google for "javascript template engine", so I think it would be helpful to inform people that it may be out of date.
